### PR TITLE
make normalization os independent by means of Pathname class

### DIFF
--- a/lib/hike/paths.rb
+++ b/lib/hike/paths.rb
@@ -1,3 +1,5 @@
+require 'pathname'
+
 module Hike
   class Paths < NormalizedArray
     def initialize(root = ".")
@@ -6,7 +8,8 @@ module Hike
     end
 
     def normalize_element(path)
-      path = File.join(@root, path) unless path[/^\//]
+	  pathname = Pathname(path)
+      path = File.join(@root, path) if pathname.relative?
       File.expand_path(path)
     end
   end


### PR DESCRIPTION
This is the first part of the fix in regard to:

https://github.com/sstephenson/brochure/issues#issue/12 [Windows supported? (or bug)]
