### PR TITLE
Test for directory existence explicitly to avoid JRuby performance issue

### DIFF
--- a/lib/hike/index.rb
+++ b/lib/hike/index.rb
@@ -77,9 +77,11 @@ module Hike
     # not exist.
     def entries(path)
       key = path.to_s
-      @entries[key] ||= Pathname.new(path).entries.reject { |entry| entry.to_s =~ /^\.|~$|^\#.*\#$/ }.sort
-    rescue Errno::ENOENT
-      @entries[key] = []
+      if File.directory?(key)
+        @entries[key] ||= Pathname.new(path).entries.reject { |entry| entry.to_s =~ /^\.|~$|^\#.*\#$/ }.sort
+      else
+        @entries[key] = []
+      end
     end
 
     # A cached version of `File.stat`. Returns nil if the file does


### PR DESCRIPTION
Another little patch to avoid using exceptions that are not JRuby's strong point.

Discovered when profiling 'assets:precompile'.  In one particular rails app, profiler shows JRuby internals getStackTrace() consuming about 20% of cpu time with 25% of that attributed to `Hike::Index#entries`.

See [netbeans profiler trace](http://i.imgur.com/RDllK.png).
