### PR TITLE
Make Hike behave consistently in unix/windows in cases of invalid paths

### DIFF
--- a/lib/hike/index.rb
+++ b/lib/hike/index.rb
@@ -78,7 +78,7 @@ module Hike
     def entries(path)
       key = path.to_s
       @entries[key] ||= Pathname.new(path).entries.reject { |entry| entry.to_s =~ /^\.|~$|^\#.*\#$/ }.sort
-    rescue Errno::ENOENT
+    rescue Errno::ENOENT, Errno::EINVAL
       @entries[key] = []
     end
 


### PR DESCRIPTION
In unix: 
/path/to/dir/http://site is throwing Errno::ENOENT so Hike returning empty array

In windows:
same path is throwing Errno::EINVAL, so Hike doesn't catch that and we get an exception
