### PR TITLE
Rename `Trail#index` to `Trail#cached`

### DIFF
--- a/lib/hike.rb
+++ b/lib/hike.rb
@@ -1,8 +1,8 @@
 module Hike
   VERSION = "1.2.0"
 
+  autoload :CachedTrail,     "hike/cached_trail"
   autoload :Extensions,      "hike/extensions"
-  autoload :Index,           "hike/index"
   autoload :NormalizedArray, "hike/normalized_array"
   autoload :Paths,           "hike/paths"
   autoload :Trail,           "hike/trail"

--- a/lib/hike/cached_trail.rb
+++ b/lib/hike/cached_trail.rb
@@ -1,22 +1,22 @@
 require 'pathname'
 
 module Hike
-  # `Index` is an internal cached variant of `Trail`. It assumes the
+  # `CachedTrail` is an internal cached variant of `Trail`. It assumes the
   # file system does not change between `find` calls. All `stat` and
-  # `entries` calls are cached for the lifetime of the `Index` object.
-  class Index
-    # `Index#paths` is an immutable `Paths` collection.
+  # `entries` calls are cached for the lifetime of the `CachedTrail` object.
+  class CachedTrail
+    # `CachedTrail#paths` is an immutable `Paths` collection.
     attr_reader :paths
 
-    # `Index#extensions` is an immutable `Extensions` collection.
+    # `CachedTrail#extensions` is an immutable `Extensions` collection.
     attr_reader :extensions
 
-    # `Index#aliases` is an immutable `Hash` mapping an extension to
+    # `CachedTrail#aliases` is an immutable `Hash` mapping an extension to
     # an `Array` of aliases.
     attr_reader :aliases
 
-    # `Index.new` is an internal method. Instead of constructing it
-    # directly, create a `Trail` and call `Trail#index`.
+    # `CachedTrail.new` is an internal method. Instead of constructing it
+    # directly, create a `Trail` and call `Trail#CachedTrail`.
     def initialize(root, paths, extensions, aliases)
       @root = root
 
@@ -35,18 +35,21 @@ module Hike
       @patterns = {}
     end
 
-    # `Index#root` returns root path as a `String`. This attribute is immutable.
+    # `CachedTrail#root` returns root path as a `String`. This attribute is immutable.
     def root
       @root.to_s
     end
 
-    # `Index#index` returns `self` to be compatable with the `Trail` interface.
-    def index
+    # `CachedTrail#cached` returns `self` to be compatable with the `Trail` interface.
+    def cached
       self
     end
 
+    # Deprecated alias for `cached`.
+    alias_method :index, :cached
+
     # The real implementation of `find`. `Trail#find` generates a one
-    # time index and delegates here.
+    # time cache and delegates here.
     #
     # See `Trail#find` for usage.
     def find(*logical_paths, &block)

--- a/lib/hike/trail.rb
+++ b/lib/hike/trail.rb
@@ -1,6 +1,6 @@
 require 'pathname'
+require 'hike/cached_trail'
 require 'hike/extensions'
-require 'hike/index'
 require 'hike/paths'
 
 module Hike
@@ -28,7 +28,7 @@ module Hike
     # allows you to require files with specifiying `foo.rb`.
     attr_reader :extensions
 
-    # `Index#aliases` is a mutable `Hash` mapping an extension to
+    # `Trail#aliases` is a mutable `Hash` mapping an extension to
     # an `Array` of aliases.
     #
     #   trail = Hike::Trail.new
@@ -136,26 +136,29 @@ module Hike
     #     end
     #
     def find(*args, &block)
-      index.find(*args, &block)
+      cached.find(*args, &block)
     end
 
-    # `Trail#index` returns an `Index` object that has the same
-    # interface as `Trail`. An `Index` is a cached `Trail` object that
+    # `Trail#cached` returns an `CachedTrail` object that has the same
+    # interface as `Trail`. An `CachedTrail` is a cached `Trail` object that
     # does not update when the file system changes. If you are
     # confident that you are not making changes the paths you are
-    # searching, `index` will avoid excess system calls.
+    # searching, `cached` will avoid excess system calls.
     #
-    #     index = trail.index
-    #     index.find "hike/trail"
-    #     index.find "test_trail"
+    #     cached = trail.cached
+    #     cached.find "hike/trail"
+    #     cached.find "test_trail"
     #
-    def index
-      Index.new(root, paths, extensions, aliases)
+    def cached
+      CachedTrail.new(root, paths, extensions, aliases)
     end
+
+    # Deprecated alias for `cached`.
+    alias_method :index, :cached
 
     # `Trail#entries` is equivalent to `Dir#entries`. It is not
     # recommend to use this method for general purposes. It exists for
-    # parity with `Index#entries`.
+    # parity with `CachedTrail#entries`.
     def entries(path)
       pathname = Pathname.new(path)
       if pathname.directory?
@@ -167,7 +170,7 @@ module Hike
 
     # `Trail#stat` is equivalent to `File#stat`. It is not
     # recommend to use this method for general purposes. It exists for
-    # parity with `Index#stat`.
+    # parity with `CachedTrail#stat`.
     def stat(path)
       if File.exist?(path)
         File.stat(path.to_s)

--- a/test/test_trail.rb
+++ b/test/test_trail.rb
@@ -22,8 +22,8 @@ module TrailTests
     assert_equal [".builder", ".coffee", ".str", ".erb"], trail.extensions
   end
 
-  def test_index
-    assert_kind_of Hike::Index, trail.index
+  def test_cached
+    assert_kind_of Hike::CachedTrail, trail.cached
   end
 
   def test_find_nonexistent_file
@@ -271,7 +271,7 @@ class TrailTest < Hike::Test
   include TrailTests
 end
 
-class IndexTest < Hike::Test
+class CachedTrailTest < Hike::Test
   attr_reader :trail
 
   def new_trail
@@ -283,7 +283,7 @@ class IndexTest < Hike::Test
     trail.alias_extension "php", "html"
     trail.alias_extension "coffee", "js"
     yield trail if block_given?
-    trail.index
+    trail.cached
   end
 
   def setup
@@ -292,34 +292,34 @@ class IndexTest < Hike::Test
 
   include TrailTests
 
-  def test_changing_trail_path_doesnt_affect_index
+  def test_changing_trail_path_doesnt_affect_cache
     trail = Hike::Trail.new(FIXTURE_ROOT)
     trail.paths.push "."
 
-    index = trail.index
+    cached = trail.cached
 
     assert_equal [fixture_path(".")], trail.paths
-    assert_equal [fixture_path(".")], index.paths
+    assert_equal [fixture_path(".")], cached.paths
 
     trail.paths.push "app/views"
 
     assert_equal [fixture_path("."), fixture_path("app/views")], trail.paths
-    assert_equal [fixture_path(".")], index.paths
+    assert_equal [fixture_path(".")], cached.paths
   end
 
-  def test_changing_trail_extensions_doesnt_affect_index
+  def test_changing_trail_extensions_doesnt_affect_cache
     trail = Hike::Trail.new(FIXTURE_ROOT)
     trail.extensions.push "builder"
 
-    index = trail.index
+    cached = trail.cached
 
     assert_equal [".builder"], trail.extensions
-    assert_equal [".builder"], index.extensions
+    assert_equal [".builder"], cached.extensions
 
     trail.extensions.push "str"
 
     assert_equal [".builder", ".str"], trail.extensions
-    assert_equal [".builder"], index.extensions
+    assert_equal [".builder"], cached.extensions
   end
 
   def test_find_does_not_reflect_changes_in_the_file_system


### PR DESCRIPTION
"index" does really make any sense. Renames the method to "cached". Old method is still aliased. Class name is also renamed.
