### PR TITLE
Split find/find_all apis

### DIFF
--- a/lib/hike/cached_trail.rb
+++ b/lib/hike/cached_trail.rb
@@ -52,27 +52,31 @@ module Hike
     # time cache and delegates here.
     #
     # See `Trail#find` for usage.
-    def find(*logical_paths, &block)
-      if block_given?
-        options = extract_options!(logical_paths)
-        base_path = Pathname.new(options[:base_path] || @root)
+    def find(*logical_paths)
+      find_all(*logical_paths).first
+    end
 
-        logical_paths.each do |logical_path|
-          logical_path = Pathname.new(logical_path.sub(/^\//, ''))
+    # The real implementation of `find_all`. `Trail#find_all` generates a one
+    # time index and delegates here.
+    #
+    # See `Trail#find_all` for usage.
+    def find_all(*logical_paths, &block)
+      return to_enum(__method__, *logical_paths) unless block_given?
 
-          if relative?(logical_path)
-            find_in_base_path(logical_path, base_path, &block)
-          else
-            find_in_paths(logical_path, &block)
-          end
-        end
+      options = extract_options!(logical_paths)
+      base_path = Pathname.new(options[:base_path] || @root)
 
-        nil
-      else
-        find(*logical_paths) do |path|
-          return path
+      logical_paths.each do |logical_path|
+        logical_path = Pathname.new(logical_path.sub(/^\//, ''))
+
+        if relative?(logical_path)
+          find_in_base_path(logical_path, base_path, &block)
+        else
+          find_in_paths(logical_path, &block)
         end
       end
+
+      nil
     end
 
     # A cached version of `Dir.entries` that filters out `.` files and

--- a/lib/hike/trail.rb
+++ b/lib/hike/trail.rb
@@ -123,20 +123,24 @@ module Hike
     #
     #     trail.find("hike") || trail.find("hike/index")
     #
-    # Though `find` always returns the first match, it is possible
-    # to iterate over all shadowed matches and fallbacks by supplying
-    # a block.
+    def find(*args)
+      index.find(*args)
+    end
+
+    # `Trail#find_all` returns all matching paths including fallbacks and
+    #  shadowed matches.
     #
-    #     trail.find("hike", "hike/index") { |path| warn path }
+    #     trail.find_all("hike", "hike/index").each { |path| warn path }
     #
-    # This allows you to filter your matches by any condition.
+    # `find_all` returns an `Enumerator`. This allows you to filter your
+    # matches by any condition.
     #
-    #     trail.find("application") do |path|
-    #       return path if mime_type_for(path) == "text/css"
+    #     trail.find_all("application").find do |path|
+    #       mime_type_for(path) == "text/css"
     #     end
     #
-    def find(*args, &block)
-      cached.find(*args, &block)
+    def find_all(*args, &block)
+      cached.find_all(*args, &block)
     end
 
     # `Trail#cached` returns an `CachedTrail` object that has the same

--- a/test/test_trail.rb
+++ b/test/test_trail.rb
@@ -178,10 +178,7 @@ module TrailTests
   end
 
   def test_find_all_respects_path_order
-    results = []
-    trail.find("layouts/interstitial.html") do |path|
-      results << path
-    end
+    results = trail.find_all("layouts/interstitial.html").to_a
     assert_equal [
       fixture_path("app/views/layouts/interstitial.html.erb"),
       fixture_path("vendor/plugins/signal_id/app/views/layouts/interstitial.html.erb")
@@ -189,10 +186,7 @@ module TrailTests
   end
 
   def test_find_all_with_multiple_extensions_respects_extension_order
-    results = []
-    trail.find("application.js") do |path|
-      results << path
-    end
+    results = trail.find_all("application.js").to_a
     assert_equal [
       fixture_path("app/views/application.js.coffee.str"),
       fixture_path("app/views/application.js.coffee.erb")


### PR DESCRIPTION
`Trail#find` was amended in 94d672741646bccde25f4ad772da0dcb2dace6df to take a block and return all matching results. Its okay, but it overloaded `find`. Really this should have a been a separate method.

This splits that behavior into `Trail#find_all`. And now that we are at least on 1.9.3, we can take more advantages of the enumerator api additions.

``` ruby
# always returns immediately with enumerator
trail.find_all("application.js")

# same as find(), just grab the first match
# enumerating is lazy, so its just as efficient 
trail.find_all("application.js").first

# in Ruby 2.0 we can use lazy
trail.find_all("application.js").lazy.select { |path| path =~ /custom constraint/ }.first
```
